### PR TITLE
Add doctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ mix run -e 'MeetupGiveaway.pick_random_attendee("https://www.meetup.com/ChicagoE
 
 ## Requirements
 
-- PhantomJS (`yarn global install phantomjs && phantomjs --wd`)
+- PhantomJS (`yarn global add phantomjs && phantomjs --wd`)

--- a/lib/meetup_giveaway.ex
+++ b/lib/meetup_giveaway.ex
@@ -6,10 +6,8 @@ defmodule MeetupGiveaway do
 
   Usage:
 
-    ```elixir
-    iex> MeetupGiveaway.pick_random_attendee("https://www.meetup.com/ChicagoElixir/events/241965932/")
-    And the winner is :: "Some Name"
-    ```
+    iex> MeetupGiveaway.pick_random_attendee("https://www.meetup.com/Chicago-Fun-Volunteers/events/242193136/")
+    "Frankye P."
   """
   def pick_random_attendee(event_url) do
     scrape_attendees(event_url)

--- a/test/meetup_giveaway_test.exs
+++ b/test/meetup_giveaway_test.exs
@@ -1,8 +1,4 @@
 defmodule MeetupGiveawayTest do
   use ExUnit.Case
   doctest MeetupGiveaway
-
-  test "greets the world" do
-    assert MeetupGiveaway.hello() == :world
-  end
 end


### PR DESCRIPTION
This removes an autogenerated test and creates a passing doctest. The link provided points to a Meetup event in the recent past with only one attendee, which allows the doctest to pass every time. Assuming these URLs are stable, this should be effective for the foreseeable future.

